### PR TITLE
add Portuguese translations for blog, navbar, footer and documentation

### DIFF
--- a/frontend/i18n/pt-BR/code.json
+++ b/frontend/i18n/pt-BR/code.json
@@ -1,0 +1,313 @@
+{
+  "theme.ErrorPageContent.title": {
+    "message": "Esta página apresentou um erro.",
+    "description": "O título da página de fallback quando a página falha"
+  },
+  "theme.blog.archive.title": {
+    "message": "Arquivo",
+    "description": "O título da página e do herói da página de arquivo do blog"
+  },
+  "theme.blog.archive.description": {
+    "message": "Arquivo",
+    "description": "A descrição da página e do herói da página de arquivo do blog"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Voltar ao topo",
+    "description": "O rótulo para o botão de voltar ao topo"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Navegação da página de listagem do blog",
+    "description": "O rótulo para a paginação do blog"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Postagens mais recentes",
+    "description": "O rótulo usado para navegar para a página de postagens mais recentes (página anterior)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Postagens mais antigas",
+    "description": "O rótulo usado para navegar para a página de postagens mais antigas (próxima página)"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Ver todas as tags",
+    "description": "O rótulo do link que direciona para a página de lista de tags"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Navegação da página de postagem do blog",
+    "description": "O rótulo para a paginação das postagens do blog"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Postagem mais recente",
+    "description": "O rótulo do botão de navegação para a postagem mais recente/anterior"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Postagem mais antiga",
+    "description": "O rótulo do botão de navegação para a postagem mais antiga/seguinte"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Alternar entre os modos claro e escuro (modo {mode} ativo)",
+    "description": "O rótulo para o alternador de modo de cor na barra de navegação"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "modo escuro",
+    "description": "O nome do modo de cor escuro"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "modo claro",
+    "description": "O nome do modo de cor claro"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Navegação por breadcrumbs",
+    "description": "O rótulo para os breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "1 item|{count} itens",
+    "description": "A descrição padrão para um cartão de categoria no índice gerado, indicando quantos itens essa categoria inclui"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Navegação das páginas de documentação",
+    "description": "O rótulo para a paginação da documentação"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Anterior",
+    "description": "O rótulo usado para navegar para o documento anterior"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Próximo",
+    "description": "O rótulo usado para navegar para o próximo documento"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "Um documento marcado|{count} documentos marcados",
+    "description": "Rótulo pluralizado para \"{count} documentos marcados\". Use tantas formas plurais (separadas por \"|\") quanto suportadas pelo idioma (veja https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} com \"{tagName}\"",
+    "description": "O título da página para uma tag de documentos"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Versão: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "Esta é uma documentação não lançada para {siteTitle} {versionLabel}.",
+    "description": "O rótulo usado para informar ao usuário que ele está visualizando uma versão de documentação não lançada"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "Esta é a documentação para {siteTitle} {versionLabel}, que não é mais mantida ativamente.",
+    "description": "O rótulo usado para informar ao usuário que ele está visualizando uma versão de documentação não mantida"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "Para a documentação mais atualizada, consulte: {latestVersionLink} ({versionLabel}).",
+    "description": "O rótulo usado para sugerir ao usuário que verifique a versão mais recente"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "última versão",
+    "description": "O rótulo usado para o link de sugestão da versão mais recente"
+  },
+  "theme.common.editThisPage": {
+    "message": "Editar esta página",
+    "description": "O rótulo do link para editar a página atual"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Link direto para {heading}",
+    "description": "Título para o link direto para o cabeçalho"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " em {date}",
+    "description": "As palavras usadas para descrever em qual data uma página foi atualizada pela última vez"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " por {user}",
+    "description": "As palavras usadas para descrever por quem a página foi atualizada pela última vez"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Última atualização {atDate}{byUser}",
+    "description": "A frase usada para exibir quando uma página foi atualizada pela última vez e por quem"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versões",
+    "description": "O rótulo para o menu suspenso de versões na barra de navegação móvel"
+  },
+  "theme.NotFound.title": {
+    "message": "Página não encontrada",
+    "description": "O título da página 404"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "O rótulo ao lado de uma lista de tags"
+  },
+  "theme.admonition.caution": {
+    "message": "cuidado",
+    "description": "O rótulo padrão usado para a advertência de Cuidado (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "perigo",
+    "description": "O rótulo padrão usado para a advertência de Perigo (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "informação",
+    "description": "O rótulo padrão usado para a advertência de Informação (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "nota",
+    "description": "O rótulo padrão usado para a advertência de Nota (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "dica",
+    "description": "O rótulo padrão usado para a advertência de Dica (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "aviso",
+    "description": "O rótulo padrão usado para a advertência de Aviso (:::warning)"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Fechar",
+    "description": "O rótulo para o botão de fechar da barra de anúncios"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Navegação de postagens recentes do blog",
+    "description": "O rótulo para as postagens recentes na barra lateral do blog"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copiado",
+    "description": "O rótulo do botão de copiar em blocos de código"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copiar código para a área de transferência",
+    "description": "O rótulo para o botão de copiar código"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copiar",
+    "description": "O rótulo do botão de copiar em blocos de código"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Alternar quebra de linha",
+    "description": "O atributo de título para o botão de alternar quebra de linha em blocos de código"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Expandir a categoria lateral '{label}'",
+    "description": "O rótulo para expandir a categoria da barra lateral"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Recolher a categoria lateral '{label}'",
+    "description": "O rótulo para recolher a categoria da barra lateral"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Navegação principal",
+    "description": "O rótulo para a navegação principal"
+  },
+  "theme.NotFound.p1": {
+    "message": "Não foi possível encontrar o que você está procurando.",
+    "description": "O primeiro parágrafo da página 404"
+  },
+  "theme.NotFound.p2": {
+    "message": "Entre em contato com o proprietário do site que o trouxe até aqui e informe que o link está quebrado.",
+    "description": "O segundo parágrafo da página 404"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Idiomas",
+    "description": "O rótulo para o menu suspenso de idiomas na barra de navegação móvel"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "Nesta página",
+    "description": "O rótulo usado pelo botão no componente de TOC recolhível"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Leia mais",
+    "description": "O rótulo usado nos resumos dos itens do blog para linkar para as postagens completas"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Leia mais sobre {title}",
+    "description": "O rótulo para o link das postagens completas a partir dos resumos"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "Leitura de um minuto|Leitura de {readingTime} minutos",
+    "description": "Rótulo pluralizado para \"{readingTime} min de leitura\". Use tantas formas plurais (separadas por \"|\") quanto suportadas pelo idioma (veja https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Página inicial",
+    "description": "O rótulo para a página inicial nos breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Recolher barra lateral",
+    "description": "O atributo de título para o botão de recolher a barra lateral da documentação"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Recolher barra lateral",
+    "description": "O rótulo para o botão de recolher a barra lateral da documentação"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Navegação da barra lateral de documentação",
+    "description": "O rótulo para a navegação da barra lateral de documentação"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Fechar barra lateral",
+    "description": "O rótulo para o botão de fechar a barra lateral móvel"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Voltar ao menu principal",
+    "description": "O rótulo do botão de voltar ao menu principal dentro do menu secundário da barra lateral móvel"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Alternar barra lateral",
+    "description": "O rótulo para o botão de menu hambúrguer da navegação móvel"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expandir barra lateral",
+    "description": "O rótulo e atributo de título para o botão de expandir a barra lateral da documentação"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expandir barra lateral",
+    "description": "O rótulo e atributo de título para o botão de expandir a barra lateral da documentação"
+  },
+  "theme.blog.post.plurals": {
+    "message": "Uma postagem|{count} postagens",
+    "description": "Rótulo pluralizado para \"{count} postagens\". Use tantas formas plurais (separadas por \"|\") quanto suportadas pelo idioma (veja https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} marcadas com \"{tagName}\"",
+    "description": "O título da página para uma tag de blog"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "O título da página para um autor do blog"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "Autores",
+    "description": "O título da página de autores"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "Ver todos os autores",
+    "description": "O rótulo do link que direciona para a página de autores do blog"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "Este autor ainda não escreveu nenhuma postagem.",
+    "description": "O texto para autores com 0 postagens no blog"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "Página não listada",
+    "description": "O título do banner de conteúdo não listado"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "Esta página não está listada. Mecanismos de busca não a indexarão, e apenas usuários com o link direto poderão acessá-la.",
+    "description": "A mensagem do banner de conteúdo não listado"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "Página em rascunho",
+    "description": "O título do banner de conteúdo em rascunho"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "Esta página é um rascunho. Ela só estará visível no ambiente de desenvolvimento e será excluída da build de produção.",
+    "description": "A mensagem do banner de conteúdo em rascunho"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Tentar novamente",
+    "description": "O rótulo do botão para tentar renderizar novamente quando o limite de erro do React captura um erro"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Pular para o conteúdo principal",
+    "description": "O rótulo de pular para o conteúdo usado para acessibilidade, permitindo navegar rapidamente para o conteúdo principal com navegação por teclado (tab/enter)"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "O título da página de lista de tags"
+  }
+}

--- a/frontend/i18n/pt-BR/docusaurus-plugin-content-blog/options.json
+++ b/frontend/i18n/pt-BR/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+  "title": {
+    "message": "Blog",
+    "description": "O título do blog usado em SEO"
+  },
+  "description": {
+    "message": "Blog",
+    "description": "A descrição do blog usada em SEO"
+  },
+  "sidebar.title": {
+    "message": "Posts recentes",
+    "description": "O rótulo para a barra lateral esquerda"
+  }
+}

--- a/frontend/i18n/pt-BR/docusaurus-plugin-content-docs/current.json
+++ b/frontend/i18n/pt-BR/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,46 @@
+{
+  "version.label": {
+    "message": "Próximo",
+    "description": "O rótulo para a versão atual"
+  },
+  "sidebar.docsSidebar.category.Scripting": {
+    "message": "Scripting",
+    "description": "O rótulo para a categoria Scripting na barra lateral docsSidebar"
+  },
+  "sidebar.docsSidebar.category.Callbacks": {
+    "message": "Callbacks",
+    "description": "O rótulo para a categoria Callbacks na barra lateral docsSidebar"
+  },
+  "sidebar.docsSidebar.category.Functions": {
+    "message": "Funções",
+    "description": "O rótulo para a categoria Funções na barra lateral docsSidebar"
+  },
+  "sidebar.docsSidebar.category.Language": {
+    "message": "Linguagem",
+    "description": "O rótulo para a categoria Linguagem na barra lateral docsSidebar"
+  },
+  "sidebar.docsSidebar.category.Reference": {
+    "message": "Referência",
+    "description": "O rótulo para a categoria Referência na barra lateral docsSidebar"
+  },
+  "sidebar.docsSidebar.category.Resources": {
+    "message": "Recursos",
+    "description": "O rótulo para a categoria Recursos na barra lateral docsSidebar"
+  },
+  "sidebar.docsSidebar.category.Server": {
+    "message": "Servidor",
+    "description": "O rótulo para a categoria Servidor na barra lateral docsSidebar"
+  },
+  "sidebar.docsSidebar.category.Client": {
+    "message": "Cliente",
+    "description": "O rótulo para a categoria Cliente na barra lateral docsSidebar"
+  },
+  "sidebar.docsSidebar.category.Tutorials": {
+    "message": "Tutoriais",
+    "description": "O rótulo para a categoria Tutoriais na barra lateral docsSidebar"
+  },
+  "sidebar.docsSidebar.category.meta": {
+    "message": "meta",
+    "description": "O rótulo para a categoria meta na barra lateral docsSidebar"
+  }
+}

--- a/frontend/i18n/pt-BR/docusaurus-plugin-content-pages/index.tsx
+++ b/frontend/i18n/pt-BR/docusaurus-plugin-content-pages/index.tsx
@@ -1,0 +1,203 @@
+import type { ReactNode } from "react";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+import Layout from "@theme/Layout";
+import HomepageFeatures from "@site/src/components/HomepageFeatures";
+import Heading from "@theme/Heading";
+import Image from "@theme/ThemedImage";
+import styles from "@site/src/pages/index.module.css";
+import Admonition from "@site/src/components/Admonition";
+
+const socials = [
+  {
+    alt: "ícone do discord",
+    src: "/images/assets/discord-icon.svg",
+    href: "https://discord.com/invite/samp",
+    size: 45,
+  },
+  {
+    alt: "ícone do facebook",
+    src: "/images/assets/facebook.svg",
+    href: "https://www.facebook.com/openmultiplayer",
+    size: 33,
+  },
+  {
+    alt: "ícone do instagram",
+    src: "/images/assets/instagram.svg",
+    href: "https://instagram.com/openmultiplayer/",
+    size: 33,
+  },
+  {
+    alt: "ícone do twitch",
+    src: "/images/assets/twitch.svg",
+    href: "https://twitch.tv/openmultiplayer",
+    size: 29,
+  },
+  {
+    alt: "ícone do x",
+    src: "/images/assets/x.svg",
+    href: "https://x.com/openmultiplayer",
+    size: 29,
+    background: false,
+  },
+  {
+    alt: "ícone do youtube",
+    src: "/images/assets/youtube.svg",
+    href: "https://youtube.com/openmultiplayer",
+    size: 35,
+  },
+];
+
+function HomepageHeader() {
+  return (
+    <header className={clsx(styles.heroBanner)}>
+      <Admonition
+        className="container"
+        type="tip"
+        title="Uma nova versão do servidor e launcher open.mp está disponível agora!"
+      >
+        A versão <b>1.4.0.2779</b> do servidor open.mp está disponível com várias correções,
+        melhorias de desempenho e novos recursos!{" "}
+        <Link to="https://www.open.mp/docs/changelog">Changelog</Link> |{" "}
+        <Link to="https://github.com/openmultiplayer/open.mp/releases/latest">
+          Download
+        </Link>
+        .
+        <br />
+        O launcher também recebeu uma atualização!{" "}
+        <Link to="https://github.com/openmultiplayer/launcher/releases/latest">
+          Veja o que há de novo
+        </Link>
+        .
+      </Admonition>
+      <div
+        className="row"
+        style={{ justifyContent: "space-evenly", alignItems: "center" }}
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "flex-start",
+            marginRight: 0,
+            marginLeft: 0,
+            maxWidth: 600,
+          }}
+        >
+          <Heading as="h1" className="hero__title" style={{ color: "#9083d2" }}>
+            Open Multiplayer
+          </Heading>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              flexDirection: "column",
+            }}
+          >
+            <p style={{ fontSize: "1.25rem" }}>
+              Um mod multiplayer para Grand Theft Auto: San Andreas que é{" "}
+              <b>totalmente compatível</b> com o{" "}
+              <b>San Andreas Multiplayer</b>.
+            </p>
+          </div>
+        </div>
+        <div
+          style={{
+            justifyContent: "space-evenly",
+          }}
+        >
+          <div className={clsx("margin-bottom--sm", styles.buttons)}>
+            <Link
+              className={clsx(
+                "button button--primary button--md",
+                styles.button
+              )}
+              title="open.mp foi lançado!"
+              to="https://github.com/openmultiplayer/open.mp/releases/latest"
+            >
+              Baixar open.mp (servidor) 🖥️
+            </Link>
+          </div>
+          <div className={clsx("margin-bottom--sm", styles.buttons)}>
+            <Link
+              className={clsx(
+                "button button--primary button--md",
+                styles.button
+              )}
+              title="Baixe o launcher do open.mp"
+              to="https://github.com/openmultiplayer/launcher/releases/latest"
+            >
+              Baixar launcher open.mp 🎮
+            </Link>
+          </div>
+          <div className={clsx("margin-bottom--sm", styles.buttons)}>
+            <Link
+              className={clsx(
+                "button button--secondary button--md",
+                styles.button
+              )}
+              to="/docs/intro"
+            >
+              Documentação 📜
+            </Link>
+          </div>
+        </div>
+      </div>
+      <div
+        className="row margin-horiz--none margin-top--xl"
+        style={{
+          justifyContent: "center",
+        }}
+      >
+        {socials.map((social, index) => {
+          const iconSize = `${social.size}px`;
+          const style: React.CSSProperties = {
+            display: "flex",
+            justifyContent: "center",
+            ...(social.background && {
+              backgroundColor: "#9083d2",
+              width: `${social.size + 17}px`,
+              height: `${social.size + 17}px`,
+              borderRadius: 5,
+            }),
+          };
+
+          return (
+            <div
+              style={{
+                width: 70,
+                height: 70,
+                alignItems: "center",
+                justifyContent: "center",
+                display: "flex",
+              }}
+            >
+              <a key={index} href={social.href} style={style} target="__blank">
+                <Image
+                  sources={{ light: social.src, dark: social.src }}
+                  alt={social.alt}
+                  width={iconSize}
+                  height={iconSize}
+                />
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </header>
+  );
+}
+
+export default function Home(): ReactNode {
+  return (
+    <Layout
+      title={`Open Multiplayer`}
+      description="Um mod multiplayer para Grand Theft Auto: San Andreas que é totalmente compatível com San Andreas Multiplayer"
+    >
+      <HomepageHeader />
+      <main>
+        <HomepageFeatures />
+      </main>
+    </Layout>
+  );
+}

--- a/frontend/i18n/pt-BR/docusaurus-theme-classic/footer.json
+++ b/frontend/i18n/pt-BR/docusaurus-theme-classic/footer.json
@@ -1,0 +1,62 @@
+{
+  "link.title.Documentations": {
+    "message": "Documentação",
+    "description": "O título da coluna de links do rodapé com título=Documentação"
+  },
+  "link.title.Community": {
+    "message": "Comunidade",
+    "description": "O título da coluna de links do rodapé com título=Comunidade"
+  },
+  "link.title.More": {
+    "message": "Mais",
+    "description": "O título da coluna de links do rodapé com título=Mais"
+  },
+  "link.item.label.Introduction": {
+    "message": "Introdução",
+    "description": "O rótulo do link no rodapé com rótulo=Introdução, redirecionando para a documentação"
+  },
+  "link.item.label.open.mp Migration": {
+    "message": "Migração para open.mp",
+    "description": "O rótulo do link no rodapé com rótulo=Migração para open.mp, redirecionando para a documentação"
+  },
+  "link.item.label.config.json": {
+    "message": "config.json",
+    "description": "O rótulo do link no rodapé com rótulo=config.json, redirecionando para docs/server/config.json"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "O rótulo do link no rodapé com rótulo=Discord, redirecionando para https://discord.gg/samp"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "O rótulo do link no rodapé com rótulo=GitHub, redirecionando para https://github.com/openmultiplayer/open.mp"
+  },
+  "link.item.label.YouTube": {
+    "message": "YouTube",
+    "description": "O rótulo do link no rodapé com rótulo=YouTube, redirecionando para https://youtube.com/openmultiplayer"
+  },
+  "link.item.label.X": {
+    "message": "X",
+    "description": "O rótulo do link no rodapé com rótulo=X, redirecionando para https://x.com/openmultiplayer"
+  },
+  "link.item.label.Servers": {
+    "message": "Servidores",
+    "description": "O rótulo do link no rodapé com rótulo=Servidores, redirecionando para /servers"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "O rótulo do link no rodapé com rótulo=Blog, redirecionando para /blog"
+  },
+  "link.item.label.SA-MP": {
+    "message": "SA-MP",
+    "description": "O rótulo do link no rodapé com rótulo=SA-MP, redirecionando para https://sa-mp.mp/"
+  },
+  "copyright": {
+  "message": "Copyright © open.mp, Inc. Criado com Docusaurus.",
+  "description": "O texto de direitos autorais no rodapé"
+},
+  "logo.alt": {
+    "message": "Logo do open.mp",
+    "description": "O texto alternativo do logo no rodapé"
+  }
+}

--- a/frontend/i18n/pt-BR/docusaurus-theme-classic/navbar.json
+++ b/frontend/i18n/pt-BR/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,34 @@
+{
+  "title": {
+    "message": "Open Multiplayer",
+    "description": "O título na barra de navegação"
+  },
+  "logo.alt": {
+    "message": "Logo do open.mp",
+    "description": "O texto alternativo do logo na barra de navegação"
+  },
+  "item.label.Docs": {
+    "message": "Documentação",
+    "description": "Item da barra de navegação com o rótulo 'Documentação'"
+  },
+  "item.label.Blog": {
+    "message": "Blog",
+    "description": "Item da barra de navegação com o rótulo 'Blog'"
+  },
+  "item.label.Forums": {
+    "message": "Fórum",
+    "description": "Item da barra de navegação com o rótulo 'Fórum'"
+  },
+  "item.label.Servers": {
+    "message": "Servidores",
+    "description": "Item da barra de navegação com o rótulo 'Servidores'"
+  },
+  "item.label.Partners": {
+    "message": "Parceiros",
+    "description": "Item da barra de navegação com o rótulo 'Parceiros'"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Item da barra de navegação com o rótulo 'GitHub'"
+  }
+}


### PR DESCRIPTION
issues found that need to be solved.

when the page is open with locales, the icons disappear:
![Screenshot 2025-02-19 004647](https://github.com/user-attachments/assets/f9185bce-a719-42c5-85aa-eb9130934c96)

couldn't translate this yet. will check later how to:
![Screenshot 2025-02-19 004724](https://github.com/user-attachments/assets/cf603c98-dfeb-4887-bcee-f1fe6e7e5187)

missing translated blog posts and some small stuff.